### PR TITLE
fix: remove unused pydantic dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 
 dependencies = [
     "typer>=0.9.0",
-    "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "jinja2>=3.0.0",
 ]


### PR DESCRIPTION
## 📝 Description

Remove `pydantic>=2.0.0` from dependencies. It is listed in `pyproject.toml` but never imported anywhere in the source code.

## 🔗 Related Issue

Fixes #15

## 🧪 Testing

- [x] Tests pass — 198 tests passing
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced
- [x] Changes tested locally