### PR TITLE
fix: correct bool type converter for string "false" value

### DIFF
--- a/src/pt_snap_cli/query/config.py
+++ b/src/pt_snap_cli/query/config.py
@@ -41,7 +41,7 @@ class QueryParameter:
             "str": str,
             "int": int,
             "float": float,
-            "bool": lambda x: bool(x) if isinstance(x, str) else x,
+            "bool": lambda x: x.lower() in ("true", "1", "yes") if isinstance(x, str) else bool(x),
         }
 
         converter = type_converters.get(self.type, str)

--- a/src/pt_snap_cli/query/mapper.py
+++ b/src/pt_snap_cli/query/mapper.py
@@ -16,7 +16,7 @@ class ResultMapper:
             "int": int,
             "float": float,
             "str": str,
-            "bool": bool,
+            "bool": lambda x: x.lower() in ("true", "1", "yes") if isinstance(x, str) else bool(x),
             "hex": lambda x: hex(x) if isinstance(x, int) else x,
             "datetime": lambda x: x,
         }

--- a/tests/query/test_config.py
+++ b/tests/query/test_config.py
@@ -24,7 +24,14 @@ class TestQueryParameter:
     def test_validate_bool(self):
         param = QueryParameter(name="test", type="bool", required=False)
         assert param.validate("true") is True
+        assert param.validate("false") is False
+        assert param.validate("True") is True
+        assert param.validate("False") is False
+        assert param.validate("1") is True
+        assert param.validate("0") is False
+        assert param.validate("yes") is True
         assert param.validate(False) is False
+        assert param.validate(True) is True
 
     def test_validate_missing_optional(self):
         param = QueryParameter(name="test", type="str", required=False, default="default")


### PR DESCRIPTION
## 📝 Description

Fix the bool type converter bug in both `config.py` and `mapper.py`. The converter was using `bool(x)` for strings, which returns `True` for any non-empty string including `"false"`.

Changed to `x.lower() in ("true", "1", "yes")` to correctly handle common boolean string representations.

## 🔗 Related Issue

Fixes #12

## 🧪 Testing

- [x] Tests updated — bool converter now tested with `"true"`, `"false"`, `"True"`, `"False"`, `"1"`, `"0"`, `"yes"`
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced
- [x] Changes tested locally