### PR TITLE
fix: replace silent pass with warnings in template loading

### DIFF
--- a/src/pt_snap_cli/query/executor.py
+++ b/src/pt_snap_cli/query/executor.py
@@ -59,9 +59,7 @@ class QueryExecutor:
                 config = QueryConfig.load_yaml(yaml_file)
                 self._configs[yaml_file.stem] = config
             except Exception as e:
-                warnings.warn(
-                    f"Failed to load query template from {yaml_file}: {e}", stacklevel=2
-                )
+                warnings.warn(f"Failed to load query template from {yaml_file}: {e}", stacklevel=2)
 
     def render(
         self,

--- a/src/pt_snap_cli/query/executor.py
+++ b/src/pt_snap_cli/query/executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -57,8 +58,10 @@ class QueryExecutor:
             try:
                 config = QueryConfig.load_yaml(yaml_file)
                 self._configs[yaml_file.stem] = config
-            except Exception:
-                pass
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to load query template from {yaml_file}: {e}", stacklevel=2
+                )
 
     def render(
         self,

--- a/src/pt_snap_cli/query/registry.py
+++ b/src/pt_snap_cli/query/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 
@@ -266,8 +267,8 @@ def _load_yaml_templates(template_dir: Path | str | None = None) -> None:
             config = QueryConfig.load_yaml(yaml_file)
             for _query_name, template in config.queries.items():
                 _registry.register(template)
-        except Exception:
-            pass
+        except Exception as e:
+            warnings.warn(f"Failed to load query template from {yaml_file}: {e}", stacklevel=2)
 
 
 def _load_all_templates() -> None:
@@ -277,5 +278,5 @@ def _load_all_templates() -> None:
 
 try:
     _load_all_templates()
-except Exception:
-    pass
+except Exception as e:
+    warnings.warn(f"Failed to load query templates: {e}", stacklevel=2)


### PR DESCRIPTION
## 📝 Description

Replace silent `except Exception: pass` blocks with `warnings.warn()` in both `registry.py` and `executor.py` template loading code.

Previously, corrupted or malformed YAML templates would silently disappear. Now a warning is emitted so users and developers can see template loading failures.

## 🔗 Related Issue

Fixes #13

## 🧪 Testing

- [x] Tests pass — no test behavior changed (only warning output added)
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced (no new warnings beyond the intended ones)
- [x] Changes tested locally