### PR TITLE
fix: narrow broad exception handling and enforce zip strictness

### DIFF
--- a/src/pt_snap_cli/cli.py
+++ b/src/pt_snap_cli/cli.py
@@ -7,7 +7,7 @@ import typer
 
 from pt_snap_cli import __version__
 from pt_snap_cli.config import ENV_DB_PATH, Config, ContextResolutionError
-from pt_snap_cli.context import Context
+from pt_snap_cli.context import Context, DatabaseNotFoundError, SchemaVersionError
 
 app = typer.Typer(
     name="pt-snap",
@@ -101,8 +101,11 @@ def use_database(
             typer.echo(f"Available devices: {', '.join(map(str, devices))}")
         else:
             typer.echo("No devices found in database.")
-    except Exception as e:
+    except (DatabaseNotFoundError, SchemaVersionError) as e:
         typer.secho(f"Error: {e}", fg=typer.colors.RED)
+        raise typer.Exit(1) from None
+    except Exception as e:
+        typer.secho(f"Error: unexpected failure opening database: {e}", fg=typer.colors.RED)
         raise typer.Exit(1) from None
 
 

--- a/src/pt_snap_cli/query/executor.py
+++ b/src/pt_snap_cli/query/executor.py
@@ -120,7 +120,7 @@ class QueryExecutor:
                 else:
                     cursor.execute(sql)
                 columns = [desc[0] for desc in cursor.description]
-                return [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]
+                return [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]
         except Exception as e:
             raise QueryExecutionError(f"Query execution failed: {e}") from e
 


### PR DESCRIPTION
## 📝 Description

Two related exception handling improvements:

1. **Narrow broad `except Exception`** in `cli.py` `use` command — now catches specific `DatabaseNotFoundError`/`SchemaVersionError` with a clearer fallback message for unexpected failures
2. **Enforce `zip(strict=True)`** in `executor.py` — catches column count mismatches early rather than silently producing wrong results

## 🔗 Related Issue

Fixes #16

## 🧪 Testing

- [x] Tests pass — no test behavior changed
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced
- [x] Changes tested locally