### PR TITLE
fix: close test coverage gaps for mapper and executor

### DIFF
--- a/tests/query/test_executor.py
+++ b/tests/query/test_executor.py
@@ -135,3 +135,49 @@ class TestQueryExecutor:
         executor.register_template(template)
 
         assert "test_query" in executor.list_templates()
+
+    def test_execute_on_all_devices(self):
+        """Test execute_on_all_devices runs template on each device."""
+        mock_context = _make_mock_context(device_ids=[0, 1])
+        executor = QueryExecutor(mock_context)
+        executor.register_template(
+            QueryTemplate(
+                name="device_test",
+                description="Test",
+                query="SELECT {{ device_id }} as dev",
+            )
+        )
+
+        results = executor.execute_on_all_devices("device_test")
+        assert 0 in results
+        assert 1 in results
+
+    def test_execute_on_all_devices_template_not_found(self):
+        """Test execute_on_all_devices raises for missing template."""
+        mock_context = _make_mock_context(device_ids=[0])
+        executor = QueryExecutor(mock_context)
+
+        from pt_snap_cli.query.executor import QueryExecutionError
+
+        with pytest.raises(QueryExecutionError, match="Template not found"):
+            executor.execute_on_all_devices("nonexistent")
+
+    def test_execute_on_all_devices_empty_device_list(self):
+        """Test execute_on_all_devices with no devices returns empty dict."""
+        mock_context = _make_mock_context(device_ids=[])
+        executor = QueryExecutor(mock_context)
+        executor.register_template(
+            QueryTemplate(name="empty_test", description="Test", query="SELECT 1")
+        )
+
+        results = executor.execute_on_all_devices("empty_test")
+        assert results == {}
+
+
+def _make_mock_context(device_ids: list[int]):
+    """Create a mock Context with the given device IDs."""
+    from unittest.mock import MagicMock
+
+    mock = MagicMock()
+    mock.device_ids = device_ids
+    return mock

--- a/tests/query/test_mapper.py
+++ b/tests/query/test_mapper.py
@@ -110,6 +110,41 @@ class TestResultMapper:
         assert len(models) == 2
         assert all(isinstance(m, MockModel) for m in models)
 
+    def test_map_to_model_not_registered_raises_keyerror(self):
+        mapper = ResultMapper()
+        with pytest.raises(KeyError) as exc_info:
+            mapper.map_to_model({"id": 1}, "MissingModel")
+        assert "MissingModel" in str(exc_info.value)
+
+    def test_map_all_to_model_propagates_keyerror(self):
+        mapper = ResultMapper()
+        with pytest.raises(KeyError):
+            mapper.map_all_to_model([{"id": 1}], "MissingModel")
+
+    def test_map_bool_string_values(self):
+        mapper = ResultMapper()
+        row = {"flag_true": "true", "flag_false": "false", "flag_1": "1", "flag_0": "0"}
+        schema = [
+            {"column": "flag_true", "type": "bool"},
+            {"column": "flag_false", "type": "bool"},
+            {"column": "flag_1", "type": "bool"},
+            {"column": "flag_0", "type": "bool"},
+        ]
+
+        result = mapper.map(row, schema)
+        assert result["flag_true"] is True
+        assert result["flag_false"] is False
+        assert result["flag_1"] is True
+        assert result["flag_0"] is False
+
+    def test_map_conversion_error_keeps_original_value(self):
+        mapper = ResultMapper()
+        row = {"value": "not_an_int"}
+        schema = [{"column": "value", "type": "int"}]
+
+        result = mapper.map(row, schema)
+        assert result["value"] == "not_an_int"
+
 
 class TestModuleFunctions:
     def test_map_result(self):


### PR DESCRIPTION
## 📝 Description

Add missing test coverage:

**Mapper** (4 new tests):
- `map_to_model` raises `KeyError` for unregistered factory (with message check)
- `map_all_to_model` propagates `KeyError`
- Bool string value conversion (`"true"`, `"false"`, `"1"`, `"0"`)
- Conversion error keeps original value

**Executor** (3 new tests):
- `execute_on_all_devices` happy path with multiple devices
- `execute_on_all_devices` raises for missing template
- `execute_on_all_devices` returns empty dict with no devices

## 🔗 Related Issue

Fixes #17

## 🧪 Testing

- [x] Tests added — 7 new test cases
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced
- [x] Changes tested locally