### PR TITLE
feat: add HAVING clause support to QueryBuilder

### DIFF
--- a/src/pt_snap_cli/query/builder.py
+++ b/src/pt_snap_cli/query/builder.py
@@ -18,6 +18,7 @@ class QueryBuilder:
         self._limit: int | None = None
         self._offset: int | None = None
         self._group_by: list[str] = []
+        self._having: list[Condition] = []
 
     def from_table(self, table: str) -> QueryBuilder:
         """Set the table to query from.
@@ -84,6 +85,21 @@ class QueryBuilder:
         self._group_by.extend(columns)
         return self
 
+    def having(self, condition: Condition) -> QueryBuilder:
+        """Add a HAVING condition.
+
+        HAVING filters groups after aggregation. Should be used
+        after a GROUP BY clause.
+
+        Args:
+            condition: Condition to add.
+
+        Returns:
+            Self for chaining.
+        """
+        self._having.append(condition)
+        return self
+
     def limit(self, n: int) -> QueryBuilder:
         """Set LIMIT clause.
 
@@ -135,6 +151,14 @@ class QueryBuilder:
         if self._group_by:
             sql += " GROUP BY " + ", ".join(self._group_by)
 
+        if self._having:
+            having_parts = []
+            for cond in self._having:
+                cond_sql, cond_params = cond.to_sql()
+                having_parts.append(cond_sql)
+                params.extend(cond_params)
+            sql += " HAVING " + " AND ".join(f"({part})" for part in having_parts)
+
         if self._order_by:
             sql += " ORDER BY " + ", ".join(self._order_by)
 
@@ -159,4 +183,5 @@ class QueryBuilder:
         self._limit = None
         self._offset = None
         self._group_by = []
+        self._having = []
         return self

--- a/tests/query/test_builder.py
+++ b/tests/query/test_builder.py
@@ -125,3 +125,55 @@ class TestQueryBuilder:
         assert "WHERE" in sql
         assert "AND" in sql
         assert "OR" in sql
+
+    def test_having_clause(self):
+        builder = QueryBuilder()
+        sql, params = (
+            builder.from_table("trace_entry_0")
+            .group_by("eventType")
+            .having(GreaterThan("COUNT(*)", 10))
+            .build()
+        )
+        assert "GROUP BY eventType" in sql
+        assert "HAVING" in sql
+        assert "(COUNT(*) > ?)" in sql
+        assert params == [10]
+
+    def test_multiple_having_clauses(self):
+        builder = QueryBuilder()
+        sql, params = (
+            builder.from_table("trace_entry_0")
+            .group_by("eventType")
+            .having(GreaterThan("COUNT(*)", 10))
+            .having(GreaterThan("SUM(size)", 1024))
+            .build()
+        )
+        assert "HAVING (COUNT(*) > ?) AND (SUM(size) > ?)" in sql
+        assert params == [10, 1024]
+
+    def test_full_query_with_having(self):
+        builder = QueryBuilder()
+        sql, params = (
+            builder.from_table("trace_entry_0")
+            .columns("eventType", "COUNT(*) as cnt")
+            .where(Equal("action", "malloc"))
+            .group_by("eventType")
+            .having(GreaterThan("COUNT(*)", 5))
+            .order_by("cnt", descending=True)
+            .limit(10)
+            .build()
+        )
+        assert sql.startswith("SELECT eventType, COUNT(*) as cnt FROM trace_entry_0")
+        assert "WHERE" in sql
+        assert "GROUP BY eventType" in sql
+        assert "HAVING" in sql
+        assert "ORDER BY cnt DESC" in sql
+        assert "LIMIT 10" in sql
+        assert params == ["malloc", 5]
+
+    def test_reset_clears_having(self):
+        builder = QueryBuilder()
+        builder.from_table("t").group_by("c").having(GreaterThan("x", 1))
+        builder.reset()
+        sql, params = builder.from_table("t").build()
+        assert "HAVING" not in sql


### PR DESCRIPTION
## 📝 Description

Add HAVING clause support to `QueryBuilder`:

- New `having(condition)` method for GROUP BY filtering
- Integrated into `build()` between GROUP BY and ORDER BY
- Multiple HAVING conditions joined with AND
- `reset()` now clears HAVING state

Usage:
```python
builder.from_table("blocks") \
    .columns("device_id", "COUNT(*) as cnt") \
    .group_by("device_id") \
    .having(GreaterThan("COUNT(*)", 100)) \
    .build()
# SELECT device_id, COUNT(*) as cnt FROM blocks GROUP BY device_id HAVING (COUNT(*) > ?)
```

## 🔗 Related Issue

Fixes #14

## 🧪 Testing

- [x] Tests added — 4 new test cases (single HAVING, multiple HAVING, full query, reset)
- [x] Manual testing completed

## ✅ Checklist

- [x] Code follows project guidelines
- [x] No new warnings introduced
- [x] Changes tested locally