### PR TITLE
fix: make --category implicitly trigger --list mode

### DIFF
--- a/src/pt_snap_cli/cli.py
+++ b/src/pt_snap_cli/cli.py
@@ -173,6 +173,10 @@ def query_database(
         list_by_category_with_details,
     )
 
+    # Implicit list mode when --category is provided without --template-use
+    if category is not None and not list_templates and not template_use and not template_info:
+        list_templates = True
+
     if list_templates:
         categories = ["basic", "statistical", "business"]
         category_labels = {


### PR DESCRIPTION
## Summary

- Allow `pt-snap query --category basic` to work without explicitly adding `--list`
- Add implicit list trigger when `--category` is provided without `--template-use` or `--template-info` (line 178-179 in `cli.py`)
- All 41 existing tests pass

Closes #30