### PR TITLE
fix: correct broken context-management links to focus-management in docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 | Topic | File |
 |-------|------|
 | Quick Start | [en/quickstart.md](en/quickstart.md) |
-| Context Management | [en/context-management.md](en/context-management.md) |
+| Context Management | [en/focus-management.md](en/focus-management.md) |
 | Querying | [en/querying.md](en/querying.md) |
 | Database Schema | [en/database.md](en/database.md) |
 | ResultMapper API | [en/result-mapper-api.md](en/result-mapper-api.md) |
@@ -15,7 +15,7 @@
 | 主题 | 文件 |
 |------|------|
 | 快速开始 | [zh/quickstart.md](zh/quickstart.md) |
-| Context 管理 | [zh/context-management.md](zh/context-management.md) |
+| Focus 管理 | [zh/focus-management.md](zh/focus-management.md) |
 | 运行查询 | [zh/querying.md](zh/querying.md) |
 | 数据库格式 | [zh/database.md](zh/database.md) |
 | ResultMapper API | [zh/result-mapper-api.md](zh/result-mapper-api.md) |


### PR DESCRIPTION
## 📝 Description
`docs/README.md` listed `context-management.md` links that point to non-existent files. The actual filenames use `focus-management.md` after the `use → focus` rename. This PR updates both EN and ZH table entries to point to the correct files.

## 🔗 Related Issue
Fixes #41

## 🧪 Testing
- [ ] Manual testing completed

## ✅ Checklist
- [x] Code follows project guidelines
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes tested locally