### PR TITLE
feat: organize query templates by subdirectory with dynamic category discovery

### DIFF
--- a/src/pt_snap_cli/cli.py
+++ b/src/pt_snap_cli/cli.py
@@ -198,7 +198,7 @@ def query_database(
         str | None,
         typer.Option(
             "--category",
-            help="Filter templates by category (basic, statistical, business)",
+            help="Filter templates by category",
             autocompletion=complete_categories,
         ),
     ] = None,
@@ -232,6 +232,7 @@ def query_database(
     """
     from pt_snap_cli.query import QueryExecutor
     from pt_snap_cli.query.registry import (
+        discover_categories,
         get_template_info,
         list_by_category_with_details,
     )
@@ -241,12 +242,8 @@ def query_database(
         list_templates = True
 
     if list_templates:
-        categories = ["basic", "statistical", "business"]
-        category_labels = {
-            "basic": "Basic Queries",
-            "statistical": "Statistical Queries",
-            "business": "Business Queries",
-        }
+        categories = discover_categories()
+        category_labels = {cat: cat.replace("_", " ").title() + " Queries" for cat in categories}
 
         if category is not None and category not in categories:
             typer.secho(

--- a/src/pt_snap_cli/completion.py
+++ b/src/pt_snap_cli/completion.py
@@ -17,8 +17,10 @@ def complete_template_names() -> list[str]:
 
 
 def complete_categories() -> list[str]:
-    """Return valid category names for shell completion."""
-    return ["basic", "statistical", "business"]
+    """Return valid category names from template directory structure for shell completion."""
+    from pt_snap_cli.query.registry import discover_categories
+
+    return discover_categories()
 
 
 def _resolve_db_for_completion() -> Path | None:

--- a/src/pt_snap_cli/query/config.py
+++ b/src/pt_snap_cli/query/config.py
@@ -90,11 +90,13 @@ class QueryTemplate:
         return validated
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> QueryTemplate:
+    def from_dict(cls, data: dict[str, Any], default_category: str | None = None) -> QueryTemplate:
         """Create QueryTemplate from dictionary.
 
         Args:
             data: Dictionary with template data.
+            default_category: Category inferred from directory structure when
+                not explicitly declared in the YAML.
 
         Returns:
             QueryTemplate instance.
@@ -116,7 +118,7 @@ class QueryTemplate:
             parameters=parameters,
             query=data.get("query", ""),
             output_schema=data.get("output_schema", []),
-            category=data.get("category", "basic"),
+            category=data.get("category") or default_category or "basic",
         )
 
 
@@ -147,11 +149,13 @@ class QueryConfig:
         return list(self.queries.keys())
 
     @classmethod
-    def load_yaml(cls, path: str | Path) -> QueryConfig:
+    def load_yaml(cls, path: str | Path, default_category: str | None = None) -> QueryConfig:
         """Load configuration from YAML file.
 
         Args:
             path: Path to YAML file.
+            default_category: Category inferred from directory structure when
+                not explicitly declared in the YAML.
 
         Returns:
             QueryConfig instance.
@@ -170,7 +174,7 @@ class QueryConfig:
         queries = {}
         for name, query_data in data.get("queries", {}).items():
             query_data["name"] = name
-            queries[name] = QueryTemplate.from_dict(query_data)
+            queries[name] = QueryTemplate.from_dict(query_data, default_category=default_category)
 
         return cls(
             version=data.get("version", "1.0"),

--- a/src/pt_snap_cli/query/registry.py
+++ b/src/pt_snap_cli/query/registry.py
@@ -271,7 +271,8 @@ def discover_categories(template_dir: Path | str | None = None) -> list[str]:
         return []
 
     return sorted(
-        d.name for d in template_dir.iterdir()
+        d.name
+        for d in template_dir.iterdir()
         if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
     )
 

--- a/src/pt_snap_cli/query/registry.py
+++ b/src/pt_snap_cli/query/registry.py
@@ -248,8 +248,57 @@ def list_by_category_with_details(category: str) -> list[dict[str, str]]:
     return _registry.list_by_category_with_details(category)
 
 
+def get_template_dir() -> Path:
+    """Return the path to the template directory."""
+    return Path(__file__).parent / "templates"
+
+
+def discover_categories(template_dir: Path | str | None = None) -> list[str]:
+    """Discover category names from subdirectory structure.
+
+    Args:
+        template_dir: Path to template directory. Defaults to package templates dir.
+
+    Returns:
+        Sorted list of category names (subdirectory names).
+    """
+    if template_dir is None:
+        template_dir = get_template_dir()
+    else:
+        template_dir = Path(template_dir)
+
+    if not template_dir.exists():
+        return []
+
+    return sorted(
+        d.name for d in template_dir.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    )
+
+
+def _infer_category(yaml_file: Path, template_dir: Path) -> str | None:
+    """Infer category from the parent directory of a YAML file.
+
+    Returns None when the file is directly under the template root
+    (not in a subdirectory), letting YAML's own category field or
+    default take precedence.
+    """
+    try:
+        parent = yaml_file.resolve().parent.name
+        template_root = template_dir.resolve().name
+        if parent != template_root:
+            return parent
+    except OSError:
+        pass
+    return None
+
+
 def _load_yaml_templates(template_dir: Path | str | None = None) -> None:
     """Load all YAML templates from the template directory.
+
+    Scans recursively (``**/*.yaml``) so that each subdirectory
+    acts as a category.  The subdirectory name is used as the
+    template's category when the YAML does not declare one.
 
     Args:
         template_dir: Path to template directory. Defaults to package templates dir.
@@ -262,9 +311,10 @@ def _load_yaml_templates(template_dir: Path | str | None = None) -> None:
     if not template_dir.exists():
         return
 
-    for yaml_file in template_dir.glob("*.yaml"):
+    for yaml_file in sorted(template_dir.glob("**/*.yaml")):
         try:
-            config = QueryConfig.load_yaml(yaml_file)
+            default_cat = _infer_category(yaml_file, template_dir)
+            config = QueryConfig.load_yaml(yaml_file, default_category=default_cat)
             for _query_name, template in config.queries.items():
                 _registry.register(template)
         except Exception as e:

--- a/src/pt_snap_cli/query/templates/basic/active_blocks.yaml
+++ b/src/pt_snap_cli/query/templates/basic/active_blocks.yaml
@@ -1,21 +1,15 @@
 version: "1.0"
 queries:
-  blocks_by_size:
-    category: basic
-    description: Get blocks filtered by size range
+  active_blocks:
+    description: Get active memory blocks (active=1)
     devices:
       - all
     parameters:
-      min_size:
-        type: int
-        default: 0
-        required: false
-        description: Minimum block size
-      max_size:
+      device_id:
         type: int
         default: null
         required: false
-        description: Maximum block size
+        description: Device ID to query
       limit:
         type: int
         default: 100
@@ -23,8 +17,7 @@ queries:
         description: Maximum rows to return
     query: |
       SELECT * FROM {{ device_block_table }}
-      WHERE size >= {{ min_size }}
-      {% if max_size is not none %}AND size <= {{ max_size }}{% endif %}
+      WHERE state = 1
       ORDER BY size DESC
       LIMIT {{ limit }}
     output_schema:
@@ -34,5 +27,11 @@ queries:
         type: hex
       - column: size
         type: int
-      - column: active
+      - column: requestedSize
+        type: int
+      - column: state
+        type: int
+      - column: allocEventId
+        type: int
+      - column: freeEventId
         type: int

--- a/src/pt_snap_cli/query/templates/basic/blocks_by_size.yaml
+++ b/src/pt_snap_cli/query/templates/basic/blocks_by_size.yaml
@@ -1,16 +1,20 @@
 version: "1.0"
 queries:
-  active_blocks:
-    category: basic
-    description: Get active memory blocks (active=1)
+  blocks_by_size:
+    description: Get blocks filtered by size range
     devices:
       - all
     parameters:
-      device_id:
+      min_size:
+        type: int
+        default: 0
+        required: false
+        description: Minimum block size
+      max_size:
         type: int
         default: null
         required: false
-        description: Device ID to query
+        description: Maximum block size
       limit:
         type: int
         default: 100
@@ -18,7 +22,8 @@ queries:
         description: Maximum rows to return
     query: |
       SELECT * FROM {{ device_block_table }}
-      WHERE state = 1
+      WHERE size >= {{ min_size }}
+      {% if max_size is not none %}AND size <= {{ max_size }}{% endif %}
       ORDER BY size DESC
       LIMIT {{ limit }}
     output_schema:
@@ -28,11 +33,5 @@ queries:
         type: hex
       - column: size
         type: int
-      - column: requestedSize
-        type: int
-      - column: state
-        type: int
-      - column: allocEventId
-        type: int
-      - column: freeEventId
+      - column: active
         type: int

--- a/src/pt_snap_cli/query/templates/basic/events_by_action.yaml
+++ b/src/pt_snap_cli/query/templates/basic/events_by_action.yaml
@@ -1,7 +1,6 @@
 version: "1.0"
 queries:
   events_by_action:
-    category: basic
     description: Get events filtered by action type
     devices:
       - all

--- a/src/pt_snap_cli/query/templates/basic/memory_timeline.yaml
+++ b/src/pt_snap_cli/query/templates/basic/memory_timeline.yaml
@@ -1,7 +1,6 @@
 version: "1.0"
 queries:
   memory_timeline:
-    category: basic
     description: Get memory allocation timeline for analysis
     devices:
       - all

--- a/src/pt_snap_cli/query/templates/business/leak_detection.yaml
+++ b/src/pt_snap_cli/query/templates/business/leak_detection.yaml
@@ -1,7 +1,6 @@
 version: "1.0"
 queries:
   leak_detection:
-    category: business
     description: Detect memory leaks by finding allocations without free events
     devices:
       - all

--- a/src/pt_snap_cli/query/templates/statistical/callstack_analysis.yaml
+++ b/src/pt_snap_cli/query/templates/statistical/callstack_analysis.yaml
@@ -1,7 +1,6 @@
 version: "1.0"
 queries:
   callstack_analysis:
-    category: statistical
     description: Analyze memory allocation by callstack
     devices:
       - all

--- a/src/pt_snap_cli/query/templates/statistical/memory_peak.yaml
+++ b/src/pt_snap_cli/query/templates/statistical/memory_peak.yaml
@@ -1,7 +1,6 @@
 version: "1.0"
 queries:
   memory_peak:
-    category: statistical
     description: Get peak memory metrics from trace events with corresponding event IDs
     devices:
       - all

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -72,10 +72,12 @@ class TestCompleteTemplateNames:
 class TestCompleteCategories:
     def test_returns_three_categories(self):
         result = complete_categories()
-        assert result == ["basic", "statistical", "business"]
+        assert len(result) == 3
+        assert set(result) == {"basic", "statistical", "business"}
 
     def test_order_is_fixed(self):
-        assert complete_categories() == ["basic", "statistical", "business"]
+        result = complete_categories()
+        assert result == sorted(result)
 
 
 class TestCompleteDeviceIds:


### PR DESCRIPTION
## 📝 Description
<!-- Briefly describe the changes in this PR -->

Reorganizes query template YAML files from a flat directory into category subdirectories (`basic/`, `business/, `statistical/`) and replaces the hardcoded `category` field + enum list with **automatic discovery from the directory structure**.

Key changes:
- Moved 7 YAML templates into 3 subdirectories matching their categories
- Removed `category:` field from YAML files — category is now inferred from the parent directory name
- `QueryRegistry._load_yaml_templates()` now recursively scans `**/*.yaml`
- `discover_categories()` dynamically returns subdirectory names
- `cli.py` replaces hardcoded `["basic", "statistical", "business"]` with dynamic discovery
- `completion.py` `complete_categories()` calls `discover_categories()` instead of returning a static list
- All CLI parameters (`--list`, `--category`, `--template-info`, `--template-use`) remain unchanged in interface and behavior

This allows new categories and templates to be added by simply placing YAML files in the appropriate subdirectory, with no code changes needed.

## 🔗 Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #43

## 🧪 Testing
<!-- Describe how you tested these changes -->
- [x] Tests added/updated
- [x] Manual testing completed

All 226 tests pass. Updated 2 test assertions in `test_completion.py` to verify the set of categories rather than hardcoded order.

## ✅ Checklist
- [x] Code follows project guidelines
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes tested locally

## 📸 Screenshots (if applicable)
<!-- Add screenshots if this PR involves UI changes -->

## 📋 Additional Notes
<!-- Any other information reviewers should know -->

Template directory structure after this change:
```
src/pt_snap_cli/query/templates/
├── basic/
│   ├── active_blocks.yaml
│   ├── blocks_by_size.yaml
│   ├── events_by_action.yaml
│   └── memory_timeline.yaml
├── business/
│   └── leak_detection.yaml
└── statistical/
    ├── callstack_analysis.yaml
    └── memory_peak.yaml
```