### PR TITLE
fix: isolate completion test from local .pt-snap/focus.json

### DIFF
--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -96,7 +96,8 @@ class TestCompleteDeviceIds:
             else:
                 os.environ["PT_SNAP_DB_PATH"] = old_env
 
-    def test_returns_empty_for_no_db(self):
+    def test_returns_empty_for_no_db(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.chdir(tmp_path)
         result = complete_device_ids()
         # Without any DB configured, should return empty list
         assert result == []


### PR DESCRIPTION
## 📝 Description
`test_returns_empty_for_no_db` fails when a local `.pt-snap/focus.json` exists because `_resolve_db_for_completion()` finds it via upward directory search from `Path.cwd()`.

Fix: use `monkeypatch.chdir(tmp_path)` to isolate the test in a clean temporary directory with no focus file.

## 🔗 Related Issue
Fixes #52

## 🧪 Testing
- [x] Tests added/updated
- [x] Manual testing completed
- [x] Lint checks passed (`ruff check .`, `black --check .`)
- [x] All 226 tests passing (previously 1 failed)

## ✅ Checklist
- [x] Code follows project guidelines
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes tested locally

## 📋 Additional Notes
Single file change in `tests/test_completion.py`.