### PR TITLE
docs: prepare changelog for 0.1.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,17 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -21,19 +26,18 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: Verify tag matches package version
+      - name: Verify built package version matches tag
         run: |
           TAG=${GITHUB_REF#refs/tags/v}
-          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          python -m pip install dist/*.whl
+          PKG_VERSION=$(python -c "from importlib.metadata import version; print(version('pt-snap-cli'))")
           if [ "$TAG" != "$PKG_VERSION" ]; then
-            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG_VERSION"
+            echo "::error::Tag v$TAG does not match built package version $PKG_VERSION"
             exit 1
           fi
 
-      - name: Verify package installs and runs
-        run: |
-          pip install dist/*.whl
-          pt-snap --version
+      - name: Verify package runs
+        run: pt-snap --version
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -68,3 +72,43 @@ jobs:
         # Alternative: token-based publishing (if OIDC not configured)
         # with:
         #   password: ${{ secrets.PYPI_API_TOKEN }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract release notes from changelog
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF"].removeprefix("refs/tags/v")
+          text = Path("CHANGELOG.md").read_text()
+          pattern = rf"^## \\[{re.escape(tag)}\\].*?$(.*?)(?=^## \\[|\\Z)"
+          match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+          if not match:
+              raise SystemExit(f"CHANGELOG.md does not contain release notes for ## [{tag}]")
+          notes = match.group(1).strip()
+          if not notes:
+              raise SystemExit(f"CHANGELOG.md release notes for ## [{tag}] are empty")
+          Path("release-notes.md").write_text(notes + "\n")
+          PY
+
+      - name: Create GitHub Release
+        run: gh release create "${GITHUB_REF#refs/tags/}" dist/* --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## [0.1.1] - 2026-06-22
+
+本次发布将 pt-snap-cli 从早期查询工具推进为面向 PyTorch 内存快照分析的 CLI + MCP 双入口工具。核心变化集中在三方面：导入链路补齐、面向 Agent 的 MCP 集成，以及更实用的内存峰值分析与查询体验。由于仓库当前没有历史发布 tag，本条目以现有 `origin/main` 全量历史和已合并 PR 元数据为依据整理。
+
+### 新增
+
+- 集成 MemSnapDump dump2db 后端，支持将 PyTorch memory snapshot pickle 转换为 SnapshotDB，补齐从快照到 SQLite 分析库的导入链路。
+- 新增 MCP server 与共享核心服务，使 CLI 能力可被 Agent 通过 MCP 调用，并补充 CLI/MCP 合约覆盖。
+- 新增峰值内存归因相关报告与查询模板，帮助定位内存峰值来源。
+- 增强 query template 体系，支持按目录组织、动态分类发现、分类过滤，以及更完整的查询构建能力。
+- 增加 shell completion，改善命令行补全体验。
+
+### 改进
+
+- 将数据库选择命令从 `use` 重命名为 `focus`，并支持持久化 device 选择，使项目级焦点配置更清晰。
+- 重构基础查询模板为更接近资源化的分页查询形式，并移除查询输出中硬编码的 10 行限制，改由 `-n` 控制。
+- 迁移到 `src` layout，整理测试目录结构，并完善中英文文档组织。
+- 增加 GitHub CI/CD、basedPyright 检查和更多测试覆盖，提升发布前质量门槛。
+
+### 修复
+
+- 修复模板加载、布尔参数转换、shell completion KeyError、分类列表触发、文档链接等问题。
+- 收窄过宽异常处理，移除未使用依赖和冗余目录，降低维护成本。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pt-snap-cli"
-version = "0.1.0b1"
+dynamic = ["version"]
 description = "PyTorch Memory Snapshot Analysis CLI"
 readme = "README.md"
 license = {text = "MIT"}
@@ -63,6 +63,10 @@ pt_snap_cli = [
     "query/templates/*.yaml",
     "query/templates/*/*.yaml",
 ]
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 100

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 WORKFLOW = Path(".github/workflows/release.yml")
 
 
@@ -30,6 +29,8 @@ def test_release_workflow_creates_github_release_from_changelog() -> None:
     text = _workflow_text()
 
     assert "Extract release notes from changelog" in text
-    assert "## [$TAG]" in text
+    assert 'removeprefix("refs/tags/v")' in text
+    assert "CHANGELOG.md does not contain release notes for ## [{tag}]" in text
+    assert "release-notes.md" in text
     assert "gh release create" in text
     assert "dist/*" in text

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_release_workflow_fetches_full_git_history_for_setuptools_scm() -> None:
+    text = _workflow_text()
+
+    assert "uses: actions/checkout@v4" in text
+    assert "fetch-depth: 0" in text
+
+
+def test_release_workflow_verifies_built_package_version_against_tag() -> None:
+    text = _workflow_text()
+
+    assert "Verify built package version matches tag" in text
+    assert "importlib.metadata" in text
+    assert "version('pt-snap-cli')" in text or 'version("pt-snap-cli")' in text
+    assert "Tag v$TAG does not match built package version" in text
+    assert "tomllib.load" not in text
+    assert "['project']['version']" not in text
+
+
+def test_release_workflow_creates_github_release_from_changelog() -> None:
+    text = _workflow_text()
+
+    assert "Extract release notes from changelog" in text
+    assert "## [$TAG]" in text
+    assert "gh release create" in text
+    assert "dist/*" in text


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with release notes for `0.1.1`
- Switch package versioning to `setuptools-scm` so tag pushes derive the published version
- Update release workflow to publish to PyPI and create a GitHub Release with `dist/*` assets
- Add regression tests for release workflow safeguards

## Release behavior
After this PR merges, release is driven by a tag such as `v0.1.1`. The workflow builds package metadata from the tag, verifies the built wheel version matches the tag, publishes to PyPI, extracts `## [0.1.1]` notes from `CHANGELOG.md`, and creates a GitHub Release.

## Verification
- `conda run -n cc pytest` — 320 passed
- `conda run -n cc ruff check .` — All checks passed
- Local temporary `v0.1.1` build check confirmed `pt_snap_cli-0.1.1-py3-none-any.whl: Version: 0.1.1`
