### PR TITLE
ci: fix release notes extraction regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
 
           tag = os.environ["GITHUB_REF"].removeprefix("refs/tags/v")
           text = Path("CHANGELOG.md").read_text()
-          pattern = rf"^## \\[{re.escape(tag)}\\].*?$(.*?)(?=^## \\[|\\Z)"
+          pattern = rf"^## \[{re.escape(tag)}\].*?$(.*?)(?=^## \[|\Z)"
           match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
           if not match:
               raise SystemExit(f"CHANGELOG.md does not contain release notes for ## [{tag}]")

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,6 +1,8 @@
+import re
 from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/release.yml")
+CHANGELOG = Path("CHANGELOG.md")
 
 
 def _workflow_text() -> str:
@@ -34,3 +36,16 @@ def test_release_workflow_creates_github_release_from_changelog() -> None:
     assert "release-notes.md" in text
     assert "gh release create" in text
     assert "dist/*" in text
+
+
+def test_release_notes_regex_extracts_current_changelog_entry() -> None:
+    tag = "0.1.1"
+    text = CHANGELOG.read_text()
+    pattern = rf"^## \[{re.escape(tag)}\].*?$(.*?)(?=^## \[|\Z)"
+
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+
+    assert match is not None
+    notes = match.group(1).strip()
+    assert notes
+    assert "MemSnapDump" in notes


### PR DESCRIPTION
## Summary
- Fix the release workflow regex used to extract `CHANGELOG.md` release notes
- Add a regression test that executes the same regex against the current `## [0.1.1]` changelog entry

## Why
The previous raw string over-escaped `[` / `]`, causing Python `re.PatternError: unterminated character set` during local release validation. If left unfixed, a `v0.1.1` tag could publish to PyPI but fail while creating the GitHub Release.

## Verification
- `conda run -n cc pytest tests/test_release_workflow.py -v` — 4 passed
- `conda run -n cc ruff check .` — All checks passed
- `conda run -n cc pytest` — 321 passed
- Local release validation: `CHANGELOG.md release notes for ## [0.1.1] found: 796 chars`
- Local tagged build validation: `pt_snap_cli-0.1.1-py3-none-any.whl: Version: 0.1.1`
