### PR TITLE
ci: set GitHub Release title from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
           PY
 
       - name: Create GitHub Release
-        run: gh release create "${GITHUB_REF#refs/tags/}" dist/* --notes-file release-notes.md
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          gh release create "$TAG" dist/* --title "$TAG" --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -35,6 +35,8 @@ def test_release_workflow_creates_github_release_from_changelog() -> None:
     assert "CHANGELOG.md does not contain release notes for ## [{tag}]" in text
     assert "release-notes.md" in text
     assert "gh release create" in text
+    assert 'TAG=${GITHUB_REF#refs/tags/}' in text
+    assert '--title "$TAG"' in text
     assert "dist/*" in text
 
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -35,7 +35,7 @@ def test_release_workflow_creates_github_release_from_changelog() -> None:
     assert "CHANGELOG.md does not contain release notes for ## [{tag}]" in text
     assert "release-notes.md" in text
     assert "gh release create" in text
-    assert 'TAG=${GITHUB_REF#refs/tags/}' in text
+    assert "TAG=${GITHUB_REF#refs/tags/}" in text
     assert '--title "$TAG"' in text
     assert "dist/*" in text
 


### PR DESCRIPTION
## Summary
- Set GitHub Release titles explicitly from the tag when creating releases
- Add workflow test coverage for `--title "$TAG"`

## Why
Without an explicit release title, GitHub can display commit/PR context such as the merge commit title instead of the concise version tag.

## Verification
- `conda run -n cc pytest tests/test_release_workflow.py -v` — 4 passed
- `conda run -n cc ruff check .` — All checks passed
